### PR TITLE
use split sections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Set some linux specific things
       if: matrix.os == 'ubuntu-latest'
       run: |
-        echo '::set-env name=LINUX_CABAL_ARGS::--enable-executable-static'
+        echo '::set-env name=LINUX_CABAL_ARGS::--enable-executable-static --ghc-options=-split-sections'
 
     - name: Build Server
       shell: bash


### PR DESCRIPTION
[`-split-sections`](https://downloads.haskell.org/ghc/8.10.1/docs/html/users_guide/phases.html#ghc-flag--split-sections) greatly reduces the size of the linux binaries, for example:

 - `hls-Linux-8.10.1.gz`: 34 MiB → 22 MiB
 - `hls-Linux-8.10.1`: 192 MiB → 115 MiB
 - `hls-wrapper-Linux.gz`: 22 MiB → 3 MiB
 - `hls-wrapper-Linux`: 115 MiB → 12 MiB

See [here](https://github.com/amesgen/haskell-language-server/releases/tag/test2) for the artifacts.